### PR TITLE
Added logic for handling 'about:blank' to download()

### DIFF
--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -629,6 +629,7 @@ def download(url, data=None, method="GET", decode=None):
     "Fetch files."
     "Technically this isn't thread-safe (even though it is being used inside threads by Tkinterweb, "
     "but as long as install_opener() is not called and a string is used as the url parameter we are okay."
+    if url == 'about:blank': return '<html><head><title>about:blank</title></head><body /></html>', url, 'html'
     thread = threadname()
     url = url.replace(" ", "%20")
     if data and (method == "POST"):


### PR DESCRIPTION
It could be placed somewhere else perhaps, if you want, but this is where made sense to me.

Basically I've been dealing with some pages that are peppered with iframes that start out pointing to 'about:blank' and it's breaking things.