### PR TITLE
populate <textarea> with text content of node

### DIFF
--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -737,6 +737,7 @@ class TkinterWeb(tk.Widget):
         widgetid = ScrolledTextBox(self, scroll_overflow=self.scroll_overflow, borderwidth=0, selectborderwidth=0, highlightthickness=0)
         widgetid.bind("<<ScrollbarShown>>", widgetid.reset_bindtags)
         widgetid.bind("<<ScrollbarHidden>>", lambda event, widgetid=widgetid: self.add_bindtags(widgetid))
+        widgetid.insert("1.0", self.get_node_text(self.get_node_children(node)))
         self.form_get_commands[node] = lambda: widgetid.get("1.0", 'end-1c')
         self.form_reset_commands[node] = lambda: widgetid.delete("0.0", "end")
         self.handle_node_replacement(node, widgetid, 

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -633,6 +633,9 @@ class ScrolledTextBox(tk.Frame):
     def get(self, *args, **kwargs):
         return self.tbox.get(*args, **kwargs)
 
+    def insert(self, *args, **kwargs):
+        return self.tbox.insert(*args, **kwargs)
+
     def delete(self, *args, **kwargs):
         self.tbox.delete(*args, **kwargs)
 


### PR DESCRIPTION
attempts to address #65.

It does populate text into the textarea *but* it doesn't correctly handle whitespace.   eg:

![rendered in TkinterWeb](https://github.com/Andereoo/TkinterWeb/assets/1487686/add7160d-00f3-4786-85c3-edd5a1fb62b2)

![rendered in firefox](https://github.com/Andereoo/TkinterWeb/assets/1487686/fa055d25-e2be-4718-bb41-785d5279e631)

I think maybe the whitespace has been squashed by the underlying Tkhtml library though?
