### PR TITLE
Filetypes from mimetypes

### DIFF
--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -669,6 +669,7 @@ class FileSelector(tk.Frame):
             alltypes = set()
             filetypes = []
             for mimetype in accept:
+                mimetype = mimetype.strip()
                 if mimetype.startswith("."):
                     extensions = [ mimetype ]
                 elif mimetype.endswith("*"):

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -665,14 +665,14 @@ class FileSelector(tk.Frame):
     
     def generate_filetypes(self, accept):
         if accept:
-            accept = accept.split(",")
-            alltypes = set()
+            accept_list = [ a.strip() for a in accept.split(",") ]
+            all_extensions = set()
             filetypes = []
-            for mimetype in accept:
-                mimetype = mimetype.strip()
-                if mimetype.startswith("."):
-                    extensions = [ mimetype ]
-                elif mimetype.endswith("*"):
+
+            # First find all the MIME types
+            for mimetype in [ a for a in accept_list if not a.startswith(".") ]:
+                # the HTML spec specifies these three wildcard cases only:
+                if mimetype in ('audio/*', 'video/*', 'image/*'):
                     extensions = [
                         k for k, v in mimetypes.types_map.items()
                         if v.startswith(mimetype[:-1])
@@ -680,13 +680,19 @@ class FileSelector(tk.Frame):
                 else:
                     extensions = mimetypes.guess_all_extensions(mimetype)
                 filetypes.append((mimetype, ' '.join(extensions)))
-                alltypes.update(extensions)
+                all_extensions.update(extensions)
+
+            # Now add any non-MIME types not already included as part of a MIME type.
+            for suffix in [ a for a in accept_list if a.startswith(".") ]:
+                if suffix not in all_extensions:
+                    filetypes.append((f"{suffix} files", suffix))
+
             if len(filetypes) > 1:
-                extensions = sorted(alltypes)
-                filetypes.insert(0, ("All Supported Types", ' '.join(extensions)))
+                filetypes.insert(0, ("All Supported Types", ' '.join(sorted(all_extensions))))
+
             self.filetypes = filetypes
         else:
-            self.filetypes = accept
+            self.filetypes = []
 
     def select_file(self):
         if self.multiple:

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -666,19 +666,23 @@ class FileSelector(tk.Frame):
     def generate_filetypes(self, accept):
         if accept:
             accept = accept.split(",")
+            alltypes = set()
             filetypes = []
             for mimetype in accept:
                 if mimetype.startswith("."):
-                    filetypes.append((mimetype, mimetype))
+                    extensions = [ mimetype ]
                 elif mimetype.endswith("*"):
-                    filetypes.append((mimetype, ' '.join(
+                    extensions = [
                         k for k, v in mimetypes.types_map.items()
                         if v.startswith(mimetype[:-1])
-                        )))
+                    ]
                 else:
-                    filetypes.append(
-                        (mimetype, ' '.join(mimetypes.guess_all_extensions(mimetype)))
-                    )
+                    extensions = mimetypes.guess_all_extensions(mimetype)
+                filetypes.append((mimetype, ' '.join(extensions)))
+                alltypes.update(extensions)
+            if len(filetypes) > 1:
+                extensions = sorted(alltypes)
+                filetypes.insert(0, ("All Supported Types", ' '.join(extensions)))
             self.filetypes = filetypes
         else:
             self.filetypes = accept

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -24,9 +24,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import mimetypes
 import sys, os
 import platform
 import threading
+
+#mimetypes.init()
 
 try:
     from urllib.request import Request, urlopen
@@ -665,27 +668,17 @@ class FileSelector(tk.Frame):
             accept = accept.split(",")
             filetypes = []
             for mimetype in accept:
-                mimetype = mimetype.replace(" ", "")
-
-                if mimetype == "image/*":
-                    mimetype = "Image files"
-                    filetypes.append((mimetype, ".apng .avif .gif .jpeg .jpg .png .svg .web, .bmp .ico .tiff",))
-                elif mimetype == "video/*":
-                    mimetype = "Video files"
-                    filetypes.append((mimetype, ".mpeg .ogg .mp4 .quicktime .mov .webm",))
-                elif mimetype == "audio/*":
-                    mimetype = "Audio files"
-                    filetypes.append((mimetype, ".aac .mpeg .flac .mp3 .wav .webm .3gpp",))
-                elif "/" in mimetype:
-                    filetype = mimetype.split("/")[-1]
-                    if filetype.lower() == "jpeg" and "jpg" not in str(accept):
-                        filetypes.append((mimetype, ".jpg",))
-                    elif filetype.lower() == "jpg" and "jpeg" not in str(accept):
-                        filetypes.append((mimetype, ".jpeg",))
-                    filetypes.append((mimetype, ".{}".format(filetypes),))
+                if mimetype.startswith("."):
+                    filetypes.append((mimetype, mimetype))
+                elif mimetype.endswith("*"):
+                    filetypes.append((mimetype, ' '.join(
+                        k for k, v in mimetypes.types_map.items()
+                        if v.startswith(mimetype[:-1])
+                        )))
                 else:
-                    filetypes.append((mimetype, mimetype,))
-
+                    filetypes.append(
+                        (mimetype, ' '.join(mimetypes.guess_all_extensions(mimetype)))
+                    )
             self.filetypes = filetypes
         else:
             self.filetypes = accept


### PR DESCRIPTION
Re: modification for #68 ... gets file types from the 'accepts' attribute via the python standard library `mimetypes`.
Includes handling for wildcard mimetypes by searching all mimetypes for matches.