### PR TITLE
Emit <<Modified>> virtual events when Combobox, FileSelector or Colou…

### DIFF
--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -790,6 +790,7 @@ class TkinterWeb(tk.Widget):
             self.form_reset_commands[node] = lambda: None
         elif nodetype == "checkbox":
             variable = tk.IntVar()
+            variable.trace('w', self.on_input_change)
             widgetid = tk.Checkbutton(self, borderwidth=0, padx=0, pady=0, highlightthickness=0, variable=variable)
             self.form_get_commands[node] = lambda: variable.get()
             self.form_reset_commands[node] = lambda: variable.set(0)
@@ -799,6 +800,7 @@ class TkinterWeb(tk.Widget):
         elif nodetype == "range":
             variable = tk.IntVar()
             variable.set(nodevalue)
+            variable.trace('w', self.on_input_change)
             from_ = self.get_node_attribute(node, "min", 0)
             to = self.get_node_attribute(node, "max", 100)
             widgetid = ttk.Scale(self, variable=variable, from_=from_, to=to)
@@ -813,6 +815,7 @@ class TkinterWeb(tk.Widget):
                 variable = self.radio_buttons[name]
             else:
                 variable = tk.StringVar(self)
+                variable.trace('w', self.on_input_change)
                 self.radio_buttons[name] = variable
             widgetid = tk.Radiobutton(self, value=nodevalue, variable=variable, tristatevalue=self.token, borderwidth=0, padx=0, pady=0, highlightthickness=0)
             self.form_get_commands[node] = lambda: variable.get()
@@ -821,8 +824,9 @@ class TkinterWeb(tk.Widget):
                 lambda widgetid=widgetid: self.handle_node_removal(widgetid), 
                 lambda node=node, widgetid=widgetid: self.handle_node_style(node, widgetid))
         else:
-            widgetid = tk.Entry(self, borderwidth=0, highlightthickness=0)
-            widgetid.insert(0, nodevalue)
+            variable = tk.StringVar(self, value=nodevalue)
+            variable.trace('w', self.on_input_change)
+            widgetid = tk.Entry(self, textvariable=variable, borderwidth=0, highlightthickness=0)
             if nodetype == "password":
                 widgetid.configure(show='*')
             widgetid.bind("<Return>", lambda event, node=node: self.handle_form_submission(node=node, event=event))
@@ -836,6 +840,9 @@ class TkinterWeb(tk.Widget):
             state = self.get_node_attribute(node, "disabled", self.token)
             if state != self.token:
                 widgetid.configure(state="disabled")
+
+    def on_input_change(self, *_):
+        self.event_generate("<<Modified>>")
 
     def on_click(self, event):
         """Set active element flags"""

--- a/tkinterweb/tkhtml/combobox-2.3.tm
+++ b/tkinterweb/tkhtml/combobox-2.3.tm
@@ -909,6 +909,7 @@ proc ::combobox::Select {w index} {
     $widgets(entry) selection range 0 end
     $widgets(entry) icursor end
 
+    event generate $widgets(this) <<Modified>>
     $widgets(this) close
 
     return ""

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -705,9 +705,11 @@ class FileSelector(tk.Frame):
             self.label.config(text=files)
         else:
             self.label.config(text="{} files selected.".format(number))
+        self.event_generate("<<Modified>>")
 
     def reset(self):
         self.label.config(text="No files selected.")
+        self.event_generate("<<Modified>>")
 
     def get_value(self):
         return self.files
@@ -754,6 +756,7 @@ class ColourSelector(tk.Frame):
         colour = colorchooser.askcolor(title = "Choose color")[1]
         self.colour = colour if colour else self.colour
         self.selector.config(bg=self.colour, activebackground=self.colour)
+        self.event_generate("<<Modified>>")
     
     def configure(self, *args, **kwargs):
         state = kwargs.pop("state")
@@ -765,6 +768,7 @@ class ColourSelector(tk.Frame):
     def reset(self):
         self.colour = self.default_colour
         self.selector.config(bg=self.colour, activebackground=self.colour)
+        self.event_generate("<<Modified>>")
 
     def get_value(self):
         return self.colour


### PR DESCRIPTION
Emit `<<Modified>>` virtual events when Combobox, FileSelector or ColourSelector widgets are modified.
This lets a user who wants to detect form changes (see #67) to do so by binding that virtual event.

I'd like to do the same to the other input fields too but for some reason `variable.trace_add('write', callback)` isn't working for me so I'll try again with `validatecommand` if I can work out how *that* works ...