### PR TITLE
fix: Notebook Invalid slave specification exception

### DIFF
--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -840,7 +840,8 @@ class Notebook(ttk.Frame):
             tabId = self.pages.index(tabId)
             return self.notebook.select(tabId)
         else:
-            return self.transcribe(self.notebook.select(tabId))
+            self.notebook.select(tabId)
+            return self.transcribe(self.notebook.select())
 
     def transcribe(self, item, reverse=False):
         return self.pages[self.notebook.index(item)]


### PR DESCRIPTION
`select()` Notebook method raises exception when called with id (0,1). 
The ttk.Notebook `select()` method returns nothing.
Thus, the return value cannot be used by transcribe method later.

Check this code snippet:

``` Python
import tkinter as tk

from tkinterweb import Notebook

window = tk.Tk()
window.geometry("640x100")
nb = Notebook(window)
page1 = tk.Label(nb, text="Page0")
page2 = tk.Label(nb, text="Page1")
nb.add(page1, text="Page0")
nb.add(page2, text="Page1")
nb.pack(side=tk.BOTTOM, fill=tk.BOTH)

tk.Button(text="Switch to 0", command=lambda : nb.select(0)).pack(side=tk.TOP, fill=tk.X)
tk.Button(text="Switch to 1", command=lambda : nb.select(1)).pack(side=tk.TOP, fill=tk.X)

window.mainloop()
```

When you press "Switch to ..." button, the Notebook page will change but  you will get:
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python3.10/tkinter/__init__.py", line 1921, in __call__
    return self.func(*args)
  File "/home/scratch_28.py", line 14, in <lambda>
    tk.Button(text="Switch to 1", command=lambda : nb.select(0)).pack(side=tk.TOP, fill=tk.X)
  File "/home/.venv/lib/python3.10/site-packages/tkinterweb/utilities.py", line 844, in select
    return self.transcribe(self.notebook.select(tabId))
  File "/home/.venv/lib/python3.10/site-packages/tkinterweb/utilities.py", line 847, in transcribe
    return self.pages[self.notebook.index(item)]
  File "/usr/lib/python3.10/tkinter/ttk.py", line 866, in index
    return self.tk.getint(self.tk.call(self._w, "index", tab_id))
_tkinter.TclError: Invalid slave specification 
```

The PR fixes this exception
