### PR TITLE
Add various Document Object Model methods to HtmlFrame

### DIFF
--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -434,6 +434,10 @@ class TkinterWeb(tk.Widget):
         """Get the text content of the given node"""
         return self.tk.call(node_handle, "text", *args)
 
+    def set_node_text(self, node_handle, new):
+        """Set the text content of the given node"""
+        return self.tk.call(node_handle, "text", "set", new)
+
     def get_node_tag(self, node_handle):
         """Get the HTML tag of the given node"""
         return self.tk.call(node_handle, "tag")
@@ -1468,6 +1472,6 @@ class TkinterWeb(tk.Widget):
         self.message_func(
             f"The text '{selected_text}' has been copied to the clipboard.")
 
-    def image(self, full=False):
-        image = self.tk.call(self._w, "image", "-full", full)
+    def image(self, full=""):
+        image = self.tk.call(self._w, "image", full)
         return {image: self.tk.call(image, "data")}

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -431,7 +431,11 @@ class TkinterWeb(tk.Widget):
         """Parse part of a document comprised of nodes just like a standard document,
         except that the document fragment isn't part of the active document. Changes
         made to the fragment don't affect the document. Returns a root node."""
-        return self.tk.call(self._w, "fragment", html)
+        self.unstoppable = True
+        html = self.crash_prevention(html)
+        fragments = self.tk.call(self._w, "fragment", html)
+        self.setup_widgets()
+        return fragments
 
     def get_node_text(self, node_handle, *args):
         """Get the text content of the given node"""

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -470,6 +470,7 @@ class TkinterWeb(tk.Widget):
         return self.tk.call(node_handle, "insert", children_nodes)
 
     def insert_node_before(self, node_handle, children_nodes, before):
+        """Same as the last one except node is placed before another node"""
         return self.tk.call(node_handle, "insert", "-before", before, children_nodes)
 
     def delete_node(self, node_handle):

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -428,9 +428,9 @@ class TkinterWeb(tk.Widget):
         return self.tk.call(self._w, "bbox", node)
 
     def parse_fragment(self, html):
-        """Part of a document comprised of nodes just like a standard document
-        difference is that the document fragment isn't part of the active document.
-        Changes made to the fragment don't affect the document. Returns a root node"""
+        """Parse part of a document comprised of nodes just like a standard document,
+        except that the document fragment isn't part of the active document. Changes
+        made to the fragment don't affect the document. Returns a root node."""
         return self.tk.call(self._w, "fragment", html)
 
     def get_node_text(self, node_handle, *args):

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -465,12 +465,12 @@ class TkinterWeb(tk.Widget):
         """Get the specified attribute of the given node"""
         return self.tk.call(node_handle, "property", node_property)
 
-    def insert_node(self, node_handle, children_nodes, before=None):
+    def insert_node(self, node_handle, children_nodes):
         """Experimental, insert the specified nodes into the parent node"""
-        if before:
-            return self.tk.call(node_handle, "insert", "-before", before, children_nodes)
-        else:
-            return self.tk.call(node_handle, "insert", children_nodes)
+        return self.tk.call(node_handle, "insert", children_nodes)
+
+    def insert_node_before(self, node_handle, children_nodes, before):
+        return self.tk.call(node_handle, "insert", "-before", before, children_nodes)
 
     def delete_node(self, node_handle):
         """Delete the given node"""

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -427,6 +427,9 @@ class TkinterWeb(tk.Widget):
         """Get the bounding box of the viewport or a specified node"""
         return self.tk.call(self._w, "bbox", node)
 
+    def parse_fragment(self, html):
+        return self.tk.call(self._w, "fragment", html)
+
     def get_node_text(self, node_handle, *args):
         """Get the text content of the given node"""
         return self.tk.call(node_handle, "text", *args)
@@ -458,9 +461,12 @@ class TkinterWeb(tk.Widget):
         """Get the specified attribute of the given node"""
         return self.tk.call(node_handle, "property", node_property)
 
-    def insert_node(self, node_handle, children_nodes):
+    def insert_node(self, node_handle, children_nodes, before=None):
         """Experimental, insert the specified nodes into the parent node"""
-        return self.tk.call(node_handle, "insert", children_nodes)
+        if before:
+            return self.tk.call(node_handle, "insert", "-before", before, children_nodes)
+        else:
+            return self.tk.call(node_handle, "insert", children_nodes)
 
     def delete_node(self, node_handle):
         """Delete the given node"""
@@ -666,7 +672,7 @@ class TkinterWeb(tk.Widget):
                     self.image_thread_check(url, name)
                     done = True
             if not done:
-                self.load_alt_image(url, name)
+                self.load_alt_text(url, name)
                 self.message_func(
                     f"The image {shorten(url)} could not be shown because it is not supported yet.")
                 self.image_setup_func(url, True)
@@ -1066,15 +1072,13 @@ class TkinterWeb(tk.Widget):
 
         self.finish_download(thread)
 
-    def load_alt_image(self, url, name):
-        if (url in self.image_directory) and self.image_alternate_text_enabled:
+    def load_alt_text(self, url, name):
+        if (url in self.image_directory):
             node = self.image_directory[url]
-            nodebox = self.bbox(node)
-            alt = self.get_node_attribute(self.image_directory[url], "alt")
-            if alt:
-                image = textimage(name, alt, nodebox, self.image_alternate_text_font, self.image_alternate_text_size, self.image_alternate_text_threshold)
-                self.loaded_images.add(image)
-            elif not self.ignore_invalid_images:
+            alt = self.get_node_attribute(node, "alt")
+            if alt and self.image_alternate_text_enabled:
+                self.insert_node(node, self.parse_fragment(alt))
+            if not self.ignore_invalid_images:
                 image = newimage(self.broken_image, name, "image/png", self.image_inversion_enabled)
                 self.loaded_images.add(image)
 
@@ -1095,24 +1099,28 @@ class TkinterWeb(tk.Widget):
                 if image:
                     self.loaded_images.add(image)
                     self.image_setup_func(url, True)
+                    for node in self.search("img"):
+                        if self.get_node_attribute(node, "src") == url:
+                            if self.get_node_children(node): self.delete_node(self.get_node_children(node))
+                            break
                 elif error == "no_pycairo":
-                    self.load_alt_image(url, name)
+                    self.load_alt_text(url, name)
                     self.message_func(
                         "Scalable Vector Graphics could not be shown because Pycairo is not installed but is required to parse .svg files.")
                     self.image_setup_func(url, False)
                 elif error == "no_rsvg":
-                    self.load_alt_image(url, name)
+                    self.load_alt_text(url, name)
                     self.message_func(
                         "Scalable Vector Graphics could not be shown because Rsvg is not installed but is required to parse .svg files.")
                     self.image_setup_func(url, False)
                 elif error == "corrupt":
-                    self.load_alt_image(url, name)
+                    self.load_alt_text(url, name)
                     self.message_func(
                         f"The image {url} could not be shown.")
                     self.image_setup_func(url, False)
 
         except Exception:
-            self.load_alt_image(url, name)
+            self.load_alt_text(url, name)
             self.message_func(
                 f"The image {url} could not be shown because it is corrupt or is not supported yet.")
             self.image_setup_func(url, False)
@@ -1459,3 +1467,7 @@ class TkinterWeb(tk.Widget):
         self.clipboard_append(selected_text)
         self.message_func(
             f"The text '{selected_text}' has been copied to the clipboard.")
+
+    def image(self, full=False):
+        image = self.tk.call(self._w, "image", "-full", full)
+        return {image: self.tk.call(image, "data")}

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -361,10 +361,12 @@ class TkinterWeb(tk.Widget):
         document node, or an empty string if the node is a text node."""
         return self.tk.call(self._w, "tag", subcommand, tag_name, *args)
 
-    def search(self, selector):
+    def search(self, selector, **kw):
         """Search the document for the specified CSS
         selector; return a Tkhtml3 node if found."""
-        return self.tk.call(self._w, "search", selector)
+        opt = ()
+        for k, v in kw.items(): opt = opt + (f"-{k}", v)
+        return self.tk.call((self._w, "search", selector)+opt)
 
     def set_zoom(self, multiplier):
         """Set the page zoom"""

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -428,6 +428,9 @@ class TkinterWeb(tk.Widget):
         return self.tk.call(self._w, "bbox", node)
 
     def parse_fragment(self, html):
+        """Part of a document comprised of nodes just like a standard document
+        difference is that the document fragment isn't part of the active document.
+        Changes made to the fragment don't affect the document. Returns a root node"""
         return self.tk.call(self._w, "fragment", html)
 
     def get_node_text(self, node_handle, *args):

--- a/tkinterweb/docs/HTMLFRAME.md
+++ b/tkinterweb/docs/HTMLFRAME.md
@@ -560,3 +560,76 @@ Parameters
 * **oldwidget** *(tkinter.Widget)* - Specifies the Tkinter widget to remove. This must be a valid Tkinter widget that is currently managed by TkinterWeb.
 
 ---
+
+#### `node_to_html(self, node, isDeep=True)`
+Converts node to HTML. 
+
+Parameters
+* **isDeep** *(boolean)* - Specifies whether to convert all child nodes as well.
+
+Return type
+* *string*
+
+---
+
+#### `get_inner_html(node)`
+Get the HTML content of a node. 
+
+Parameters
+* **node** *(node)* - Node in question.
+
+Return type
+* *string*
+
+---
+
+#### `set_inner_html(node, new)`
+Get the HTML content of a node. 
+
+Parameters
+* **node** *(node)* - Node in question.
+* **string** *(string)* - New inner HTML.
+
+---
+
+#### `create_element(tagname)`
+Create a new node of specified type. 
+
+Parameters
+* **string** *(string)* - New node type e.g. <P>.
+
+Return type
+* *node*
+
+---
+
+#### `create_text_node(text)`
+Create a new text node. 
+
+Parameters
+* **string** *(string)* - New text.
+
+Return type
+* *node*
+
+---
+
+#### `text_content(node, text=None)`
+Return or change the text content of a node.
+
+Parameters
+* **node** *(node)* - Node in question.
+* **string** *(string)* - New text.
+
+Return type
+* *node*
+
+---
+
+#### `body()`
+Returns a document's <body> element.
+
+Return type
+* *node*
+
+---

--- a/tkinterweb/docs/HTMLFRAME.md
+++ b/tkinterweb/docs/HTMLFRAME.md
@@ -588,7 +588,7 @@ Get the HTML content of a node.
 
 Parameters
 * **node** *(node)* - Node in question.
-* **string** *(string)* - New inner HTML.
+* **new** *(string)* - New inner HTML.
 
 ---
 
@@ -596,7 +596,7 @@ Parameters
 Create a new node of specified type. 
 
 Parameters
-* **string** *(string)* - New node type e.g. <P>.
+* **tagname** *(string)* - New node type e.g. <P>.
 
 Return type
 * *node*
@@ -619,7 +619,7 @@ Return or change the text content of a node.
 
 Parameters
 * **node** *(node)* - Node in question.
-* **string** *(string)* - New text.
+* **new** *(string)* - New text.
 
 Return type
 * *node*

--- a/tkinterweb/docs/HTMLFRAME.md
+++ b/tkinterweb/docs/HTMLFRAME.md
@@ -607,7 +607,7 @@ Return type
 Create a new text node. 
 
 Parameters
-* **string** *(string)* - New text.
+* **text** *(string)* - New text.
 
 Return type
 * *node*
@@ -619,7 +619,7 @@ Return or change the text content of a node.
 
 Parameters
 * **node** *(node)* - Node in question.
-* **new** *(string)* - New text.
+* **text** *(string)* - New text.
 
 Return type
 * *node*

--- a/tkinterweb/docs/TKINTERWEB.md
+++ b/tkinterweb/docs/TKINTERWEB.md
@@ -150,7 +150,7 @@ Parse CSS code.
 
 ---
 #### `parse_fragment(html)`
-Part of a document comprised of nodes just like a standard document difference is that the document fragment isn't part of the active document. Changes made to the fragment don't affect the document. Returns a root node.
+Parse part of a document comprised of nodes just like a standard document, except that the document fragment isn't part of the active document. Changes made to the fragment don't affect the document. Returns a root node.
 
 ---
 #### `remove_node_flags(node, name)`
@@ -198,7 +198,7 @@ Set the page render mode.
 
 ---
 #### `set_node_text(mode)`
-Set the text content of the given node.
+Set the text content of the given text node.
 
 ---
 #### `set_zoom(multiplier)`

--- a/tkinterweb/docs/TKINTERWEB.md
+++ b/tkinterweb/docs/TKINTERWEB.md
@@ -129,6 +129,10 @@ Return the page zoom.
 Experimental, insert the specified nodes into the parent node.
 
 ---
+#### `insert_node_before(node_handle, children_nodes, before)`
+Same as the last one except node is placed before another node.
+
+---
 #### `node(*args)`
 Retrieve one or more document  node handles from the current document.       
 
@@ -143,6 +147,10 @@ Parse HTML code.
 ---
 #### `parse_css(sheetid=None, importcmd=None, data='')`
 Parse CSS code.
+
+---
+#### `parse_fragment(html)`
+Part of a document comprised of nodes just like a standard document difference is that the document fragment isn't part of the active document. Changes made to the fragment don't affect the document. Returns a root node.
 
 ---
 #### `remove_node_flags(node, name)`
@@ -187,6 +195,10 @@ Set dynamic flags on the given node.
 ---
 #### `set_parsemode(mode)`
 Set the page render mode.
+
+---
+#### `set_node_text(mode)`
+Set the text content of the given node.
 
 ---
 #### `set_zoom(multiplier)`

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -583,8 +583,9 @@ class HtmlFrame(ttk.Frame):
         )
 
     def set_inner_html(self, node, new):
-        if extract_nested(node) is None: raise ValueError("Node is empty.")
+        if not node: raise ValueError("Node is empty.")
         self.tk.eval("""
+            set tkw %s
             set node %s
             
             if {[$node tag] eq ""} {error "$node is not an HTMLElement"}
@@ -597,11 +598,15 @@ class HtmlFrame(ttk.Frame):
             }
 
             set newHtml "%s"
+            set oldmode [$tkw cget -parsemode]
+            $tkw configure -parsemode html
             # Insert the new descendants, created by parseing $newHtml.
-            set children [%s fragment $newHtml]
+            set children [$tkw fragment $newHtml]
             $node insert $children
+
+            $tkw configure -parsemode $oldmode
             update
-            """ % (extract_nested(node), escape_Tcl(new), self.html)
+            """ % (self.html, extract_nested(node), escape_Tcl(new))
         )
 
     def create_element(self, tagname):

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -632,7 +632,19 @@ class HtmlFrame(ttk.Frame):
 
     def text_content(self, node, text=None):
         return self.tk.eval("""
+            proc get_child_text {node} {
+                set t ""
+                foreach child [$node children] {
+                    if {[$child tag] eq ""} {
+                        append t [$child text -pre]
+                    } else {
+                        append t [get_child_text $child]
+                    }
+                }
+                return $t
+            }
             set node %s
+            if {$node eq ""} {error "DOMException NOT_SUPPORTED_ERR"}
             set textnode %s
             if {$textnode ne ""} {
                 foreach child [$node children] {
@@ -640,12 +652,7 @@ class HtmlFrame(ttk.Frame):
                 }
                 $node insert $textnode
             } else {
-                set ret ""
-                foreach child [$node children] {
-                    append ret [$child text -pre]
-                    append ret [text_content_get $child ""]
-                }
-                return $ret
+                return [get_child_text $node]
             }
             """ % (extract_nested(node), self.create_text_node(text) if text else '""')
         )

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -571,11 +571,19 @@ class HtmlFrame(ttk.Frame):
                 $child destroy
             }
 
-            set newHtml %s
+            set newHtml "%s"
             # Insert the new descendants, created by parseing $newHtml.
             set children [%s fragment $newHtml]
             $node insert $children
             """ % (extract_nested(node), new, self.html)
+        )
+
+    def createElement(self, tagname):
+        return self.tk.eval("""
+            set node [%s fragment "<%s>"]
+            if {$node eq ""} {error "DOMException NOT_SUPPORTED_ERR"}
+            return $node
+            """ % (self.html, tagname)
         )
 
 

--- a/tkinterweb/imageutils.py
+++ b/tkinterweb/imageutils.py
@@ -142,3 +142,13 @@ def blankimage(name):
     image = Image.new("RGBA", (1, 1))
     image = PhotoImage(image, name=name)
     return image
+
+def createRGBimage(data, name, w, h):
+    image = Image.new("RGB", (w, h))
+    for y, row in enumerate(data):
+        for x, hexc in enumerate(row.split()):
+            rgb = tuple(int(hexc[1:][i:i+2], 16) for i in (0, 2, 4))
+            image.putpixel((x, y), rgb)
+
+    if name: image.save(name)
+    return image

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -1023,3 +1023,8 @@ def tkhtml_notifier(name, text, *args):
         sys.stdout.write("DEBUG "+str(name)+": "+str(text)+"\n\n")
     except Exception:
         pass
+
+def extract_nested(nested):
+    if isinstance(nested, tuple):
+        return extract_nested(nested[0])
+    return nested

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -1024,7 +1024,19 @@ def tkhtml_notifier(name, text, *args):
     except Exception:
         pass
 
+
 def extract_nested(nested):
-    if isinstance(nested, tuple):
+    if isinstance(nested, tuple) and len(nested):
         return extract_nested(nested[0])
     return nested
+
+
+def escape_Tcl(string):
+    string = str(string)
+    escaped = ""
+    special_chars = '"\\$[]'
+    for char in string:
+        if char in special_chars: escaped += "\\"
+        escaped += char
+
+    return escaped


### PR DESCRIPTION
Added set_inner_html, get_inner_html, node_to_html, createElement and create_text_node to htmlwidgets.py and one support feature to bindings.py. The image() and load_alt() are to be ignored as they only work with my personal, modified version of Tkhtml3 and will not work on the build used here.

Theses new features where copied over from code found in the Html Viewer (hv) source files, you can browse them yourself to find more if you want.

Tests: [Tests.zip](https://github.com/user-attachments/files/18129977/Tests.zip)


