### PR TITLE
Minor adjustments to branch "Experimental"

### DIFF
--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -679,13 +679,9 @@ class TkinterWeb(tk.Widget):
         if stylecmd:
             if handledelete:
                 self.tk.call(
-                    node,
-                    "replace",
-                    widgetid,
-                    "-deletecmd",
-                    self.register(deletecmd),
-                    "-stylecmd",
-                    self.register(stylecmd),
+                    node, "replace", widgetid,
+                    "-deletecmd", self.register(deletecmd),
+                    "-stylecmd", self.register(stylecmd),
                 )
             else:
                 self.tk.call(

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -658,6 +658,9 @@ class TkinterWeb(tk.Widget):
             if image:
                 self.loaded_images.add(image)
                 self.post_message(f"Successfully loaded {shorten(url)}")
+                if self.experimental:
+                    node = self.search(f'img[src="{url}"]')
+                    if self.get_node_children(node): self.delete_node(self.get_node_children(node))
             elif error == "no_pycairo":
                 self.load_alt_text(url, name)
                 self.post_message(f"Error loading image {url}: Pycairo is not installed but is required to parse .svg files")

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -1266,13 +1266,13 @@ class TkinterWeb(tk.Widget):
             name = url.replace("replace:", "")
             self._finish_download(thread)
         elif any(
-            [
+            frozenset({
                 url.startswith("linear-gradient("),
                 url.startswith("url("),
                 url.startswith("radial-gradient("),
                 url.startswith("repeating-linear-gradient("),
                 url.startswith("repeating-radial-gradient("),
-            ]
+            })
         ):
             done = False
             self.post_message(f"Fetching image: {shorten(url)}")
@@ -1416,14 +1416,7 @@ class TkinterWeb(tk.Widget):
         )
         nodevalue = self.get_node_attribute(node, "value")
 
-        if any(
-            (
-                nodetype == "image",
-                nodetype == "submit",
-                nodetype == "reset",
-                nodetype == "button",
-            )
-        ):
+        if nodetype in frozenset({"image", "submit", "reset", "button"}):
             widgetid = None
             self.form_get_commands[node] = placeholder
             self.form_reset_commands[node] = placeholder

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -347,35 +347,29 @@ Use the parameter `messages_enabled = False` when calling HtmlFrame() or HtmlLab
             self.html.post_message("A screenshot could not be taken because it screenshot_page is an experimental feature on Windows")
             return None
 
-    def print_page(self, file=None, cnf={}, **kwargs):
+    def print_page(self, filename=None, cnf={}, **kwargs):
         "Print the page"
         if self.html.experimental:
             cnf |= kwargs
             self.html.post_message(f"Printing {self.current_url}...")
-            if file:
-                cnf["file"] = file
+            if filename:
+                cnf["file"] = filename
             if "pagesize" in cnf:
-                pageheights = {
-                    "A3": "1191", "A4": "842", "A5": "595",
-                    "LEGAL": "792", "LETTER": "1008"
-                }
-                pagewidths = {
-                    "A3": "842", "A4": "595", "A5": "420",
-                    "LEGAL": "612", "LETTER": "612"
+                pagesizes = {
+                    "A3": "842x1191", "A4": "595x842", "A5": "420x595",
+                    "Legal": "612x792", "Letter": "612x1008"
                 }
                 try:
-                    cnf["pageheight"] = pageheights[cnf["pagesize"].upper()]
-                    cnf["pagewidth"] = pagewidths[cnf["pagesize"].upper()]
-                    self.html.post_message(f"Setting printer page size to {cnf['pageheight']}px by {cnf['pagewidth']}px.")
+                    cnf["pagesize"] = pagesizes[cnf["pagesize"].upper()]
+                    self.html.post_message(f"Setting printer page size to {cnf['pagesize']} PostScript points.")
                 except KeyError:
                     raise KeyError("Parameter 'pagesize' must be A3, A4, A5, Legal, or Letter")
-                del cnf["pagesize"]
 
             self.html.update() # update the root window to ensure HTML is rendered
             file = self.html.postscript(cnf)
             # no need to save - Tkhtml handles that for us
             self.html.post_message("Printed!")
-            return file
+            if file: return file
         else:
             self.html.post_message("The page could not be printed because print_page is an experimental feature")
             return ""


### PR DESCRIPTION
The changes to 'finish_fetching_images' are necessary to remove the child text nodes if the [image is replaced](https://github.com/Andereoo/TkinterWeb/issues/73#issuecomment-1595885220)

"-pagesize" is a new argument used by the "postscript" command. It makes the layout engine [fragment into discrete pages](https://www.w3.org/TR/css-break-3/#intro), the height x width (in that order) of each page is in either `c` for centimetres, `i` for inches, `m` for millimetres, or `p` or nothing for printer's points (1/72 inch)
Examples:
- `100x100c` one hundred by one hundred centimetres
- `100ix100c` one hundred inches by one hundred centimetres

Frozensets were chosen as the iterable content doesn't change.

Also `HtmlFrame.on_image_setup()` was removed, why is this?