### PR TITLE
Fixed bug where <img> alt text won't load

### DIFF
--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -603,28 +603,24 @@ class TkinterWeb(tk.Widget):
         self._finish_download(thread)
 
     def load_alt_text(self, url, name):
-        if self.image_alternate_text_enabled and (url in self.image_directory):
+        if (url in self.image_directory):
             node = self.image_directory[url]
             alt = self.get_node_attribute(node, "alt")
-            if self.experimental:
-                # eventually this will be all we need
-                if alt: 
+            if alt and self.image_alternate_text_enabled:
+                if self.experimental:
                     self.insert_node(node, self.parse_fragment(alt))
-            else:
-                nodebox = self.bbox(node)
-                if alt:
+                else:
+                    nodebox = self.bbox(node)
                     image = text_to_image(
-                        name,
-                        alt,
-                        nodebox,
+                        name, alt, nodebox,
                         self.image_alternate_text_font,
                         self.image_alternate_text_size,
                         self.image_alternate_text_threshold,
                     )
                     self.loaded_images.add(image)
-        elif not self.ignore_invalid_images:
-            image, error = data_to_image(BROKEN_IMAGE, name, "image/png", self._image_inversion_enabled)
-            self.loaded_images.add(image)
+            if not self.ignore_invalid_images:
+                image = newimage(self.broken_image, name, "image/png", self.image_inversion_enabled)
+                self.loaded_images.add(image)
 
     def fetch_images(self, url, name, urltype):
         "Fetch images and display them in the document"

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -608,16 +608,15 @@ class TkinterWeb(tk.Widget):
                 if self.experimental:
                     self.insert_node(node, self.parse_fragment(alt))
                 else:
-                    nodebox = self.bbox(node)
                     image = text_to_image(
-                        name, alt, nodebox,
+                        name, alt, self.bbox(node),
                         self.image_alternate_text_font,
                         self.image_alternate_text_size,
                         self.image_alternate_text_threshold,
                     )
                     self.loaded_images.add(image)
             if not self.ignore_invalid_images:
-                image = newimage(self.broken_image, name, "image/png", self.image_inversion_enabled)
+                image, error = data_to_image(BROKEN_IMAGE, name, "image/png", self._image_inversion_enabled)
                 self.loaded_images.add(image)
 
     def fetch_images(self, url, name, urltype):

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -353,16 +353,11 @@ class HTMLElement:
         )
 
     @property
-<<<<<<< HEAD
     def textContent(self):  # Original for this project
-        "Get the text content of an element."
-=======
-    def textContent(self):  # original for this project
         """Get and set the text content of an element. Cannot be used on ``<html>`` elements.
         
         :rtype: str
         :raises: :py:class:`tkinter.TclError`"""
->>>>>>> ced842f1523235d9dacc362e3a6caa7a1df4ab8e
         return self.html.tk.eval("""
             proc get_child_text {node} {
                 set txt ""
@@ -413,20 +408,11 @@ class HTMLElement:
 
     @property
     def parentElement(self):
-<<<<<<< HEAD
-        "Return the element's parent element"
-        return HTMLElement(self, self.html.get_node_parent(self.node))
-
-    @property
-    def children(self):
-        "Return the element's children elements"
-        return [HTMLElement(self, i) for i in self.html.get_node_children(self.node)]
-=======
         """Get the element's parent element.
         
         :rtype: :class:`HTMLElement`
         :raises: :py:class:`tkinter.TclError`"""
-        return HTMLElement(self.html, self.html.get_node_parent(self.node))
+        return HTMLElement(self, self.html.get_node_parent(self.node))
 
     @property
     def children(self):
@@ -434,8 +420,7 @@ class HTMLElement:
         
         :rtype: list(:class:`HTMLElement`)
         :raises: :py:class:`tkinter.TclError`"""
-        return [HTMLElement(self.html, i) for i in self.html.get_node_children(self.node)]
->>>>>>> ced842f1523235d9dacc362e3a6caa7a1df4ab8e
+        return [HTMLElement(self, i) for i in self.html.get_node_children(self.node)]
 
     def getAttribute(self, attribute):
         """Return the value of the given attribute..

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -286,9 +286,9 @@ class HTMLElement:
     :type htmlwidget: :class:`~tkinterweb.TkinterWeb`
     :param node: The Tkhtml3 node this class represents.
     :type node: Tkhtml3 node"""
-    def __init__(self, tkw, node):
-        self.tkw = tkw
-        self.html = tkw.html
+    def __init__(self, htmlFrame, node):
+        self.tkw = htmlFrame
+        self.html = htmlFrame.html
         self.node = node
         self.styleCache = None  # initialize style as None
         self.html.bbox(node)  # check if the node is valid

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -61,7 +61,7 @@ class HTMLDocument:
 
     def createTextNode(self, text):  # taken from hv3_dom_core.tcl line 219
         "Create a new text node with the given text conent"
-        return htmlwidget.tk.eval("""
+        return self.html.tk.eval("""
             set tkw %s
             set text "%s"
             if {$text eq ""} {
@@ -75,7 +75,7 @@ class HTMLDocument:
                 set node [parse_fragment $escaped]
             }
             return $node
-            """ % (htmlwidget, escape_Tcl(text))
+            """ % (self.html, escape_Tcl(text))
         )
 
     @property
@@ -263,41 +263,40 @@ class HTMLElement:
         )
 
     @property
-    def textContent(self):  # original for this project
+    def textContent(self):  # Original for this project
         "Get the text content of an element."
         return self.html.tk.eval("""
             proc get_child_text {node} {
-                set z ""
+                set txt ""
                 foreach child [$node children] {
                     if {[$child tag] eq ""} {
-                        append z [$child text -pre]
+                        append txt [$child text -pre]
                     } else {
-                        append z [get_child_text $child]
+                        append txt [get_child_text $child]
                     }
                 }
-                return $z
+                return $txt
             }
-            set node %s
-            return [get_child_text $node]
+            return [get_child_text %s]
             """ % extract_nested(self.node)
         )
 
     @textContent.setter
-    def textContent(self, contents):  # ditto
+    def textContent(self, contents):  # Ditto
         "Set the text content of an element."
         self.html.tk.eval("""
             set node %s
-            set tag [$node tag]
             set textnode %s
             if {$textnode eq ""} {error "$node is empty"}
-            if {$tag eq "html"} {error "textContent cannot be set on <$tag> elements"}
+            if {[$node tag] eq "html"} {error "textContent cannot be set on <$tag> elements"}
             $node remove [$node children]
-            #foreach child [$node children] {
-            #    $child destroy
-            #}
+            foreach child [$node children] {
+                $child destroy
+            }
             $node insert $textnode
+            
             update  ;# This must be done to see changes on-screen
-            """ % (extract_nested(self.node), createTextNode)
+            """ % (extract_nested(self.node), self.dom.createTextNode(contents))
         )
 
     @property

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -165,7 +165,7 @@ class CSSStyleDeclaration:
         self.node = node
 
     def __getitem__(self, prop):
-        return self.html.get_node_property(self.node, prop)
+        return self.html.get_node_property(self.node, prop, "-inline")
 
     def __setitem__(self, prop, value):
         style = self.html.get_node_properties(self.node, "-inline")

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -128,7 +128,7 @@ class HTMLDocument:
         nodes = self.html.search(query)
         return tuple(HTMLElement(self, node) for node in nodes)
     
-    def _node_to_html(self, node, deep=True):
+    def _node_to_html(self, node, deep=True):  # From hv3_dom_core.tcl line 311 and line 329
         return self.html.tk.eval(r"""
             proc TclNode_to_html {node} {
                 set tag [$node tag]
@@ -156,7 +156,7 @@ class HTMLDocument:
             }
             return [TclNode_to_html %s]
             """ % (int(deep), extract_nested(node))
-        )
+        ) # May split this into 2 methods in future
 
 
 class CSSStyleDeclaration:
@@ -225,14 +225,14 @@ class HTMLElement:
         "Get the inner HTML of an element"
         return self.html.tk.eval("""
             set node %s
-                if {[$node tag] eq ""} {error "$node is not an HTMLElement"}
+            if {[$node tag] eq ""} {error "$node is not an HTMLElement"}
 
-                set ret ""
-                foreach child [$node children] {
-                    append ret [node_to_html $child 1]
-                }
-                update
-                return $ret
+            set ret ""
+            foreach child [$node children] {
+                append ret [node_to_html $child 1]
+            }
+            update
+            return $ret
             """ % extract_nested(self.node)
         )
 

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -118,8 +118,7 @@ class HTMLDocument:
         :type query: str
         :rtype: :class:`HTMLElement`
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = f"[id='{query}']"
-        node = self.html.search(newquery, index=0)
+        node = self.html.search(f"[id='{query}']", index=0)
         return HTMLElement(self, node)
 
     def getElementsByClassName(self, query):
@@ -129,8 +128,7 @@ class HTMLDocument:
         :type query: str
         :rtype: tuple[:class:`HTMLElement`]
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = [f".{i}" for i in query.split()]
-        nodes = self.html.search(" ".join(newquery))
+        nodes = self.html.search(" ".join(f".{i}" for i in query.split()))
         return tuple(HTMLElement(self, node) for node in nodes)
 
     def getElementsByName(self, query):
@@ -140,8 +138,7 @@ class HTMLDocument:
         :type query: str
         :rtype: tuple[:class:`HTMLElement`]
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = f"[name='{query}']"
-        nodes = self.html.search(newquery)
+        nodes = self.html.search(f"[name='{query}']")
         return tuple(HTMLElement(self, node) for node in nodes)
 
     def getElementsByTagName(self, query):
@@ -463,8 +460,7 @@ class HTMLElement:
         :type query: str
         :rtype: :class:`HTMLElement`
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = f"[id='{query}']"
-        node = self.html.search(newquery, index=0, root=self.node)
+        node = self.html.search(f"[id='{query}']", index=0, root=self.node)
         return HTMLElement(self, node)
 
     def getElementsByClassName(self, query):
@@ -474,8 +470,7 @@ class HTMLElement:
         :type query: str
         :rtype: tuple[:class:`HTMLElement`]
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = [f".{i}" for i in query.split()]
-        nodes = self.html.search(" ".join(newquery), root=self.node)
+        nodes = self.html.search(" ".join(f".{i}" for i in query.split()), root=self.node)
         return tuple(HTMLElement(self, node) for node in nodes)
 
     def getElementsByName(self, query):
@@ -485,8 +480,7 @@ class HTMLElement:
         :type query: str
         :rtype: tuple[:class:`HTMLElement`]
         :raises: :py:class:`tkinter.TclError`"""
-        newquery = f"[name='{query}']"
-        nodes = self.html.search(newquery, root=self.node)
+        nodes = self.html.search(f"[name='{query}']", root=self.node)
         return tuple(HTMLElement(self, node) for node in nodes)
 
     def getElementsByTagName(self, query):

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -282,18 +282,13 @@ class CSSStyleDeclaration:
     
 
 class HTMLElement:
-<<<<<<< HEAD
-    def __init__(self, dom, node):
-        self.dom = dom
-        self.html = dom.html
-=======
     """:param htmlwidget: The :class:`~tkinterweb.TkinterWeb` instance this class is tied to.
     :type htmlwidget: :class:`~tkinterweb.TkinterWeb`
     :param node: The Tkhtml3 node this class represents.
     :type node: Tkhtml3 node"""
-    def __init__(self, htmlwidget, node):
-        self.html = htmlwidget
->>>>>>> ced842f1523235d9dacc362e3a6caa7a1df4ab8e
+    def __init__(self, tkw, node):
+        self.tkw = tkw
+        self.html = tkw.html
         self.node = node
         self.styleCache = None  # initialize style as None
         self.html.bbox(node)  # check if the node is valid
@@ -399,7 +394,7 @@ class HTMLElement:
             $node insert $textnode
             
             update  ;# This must be done to see changes on-screen
-            """ % (extract_nested(self.node), self.dom.createTextNode(contents))
+            """ % (extract_nested(self.node), self.tkw.createTextNode(contents))
         )
 
     @property

--- a/tkinterweb/tkhtml/win_amd64/pkgIndex.tcl
+++ b/tkinterweb/tkhtml/win_amd64/pkgIndex.tcl
@@ -1,4 +1,0 @@
-package ifneeded Tkhtml 3.0 [string map [list @ $dir] {
-	load [file join {@} Tkhtml30.dll]
-	package provide Tkhtml 3.0
-}]


### PR DESCRIPTION
Turns out that image alt text will not load if done that way - so I reincorporated some of the code from my original  branch, it loads the text in "experimental mode".

I also modified the DOM file to simplify function calling and variable usage in varying levels of debatable usefulness. Including that I add a variable that references the `HTMLElement`'s parent `HTMLDocument` (`self.tkw`), this is used in the script (`@textContent.setter`), but I think it is appropriate that the `HTMLElement` has access to the object that spawned it.