### PR TITLE
Some Bug Fixes and Code Refactoring

### DIFF
--- a/examples/TkinterWebBrowser.py
+++ b/examples/TkinterWebBrowser.py
@@ -267,8 +267,7 @@ class Page(ttk.Frame):
 
         self.sidebar.javascript.register("frame", frame)
 
-        self.sidebar.load_html(f"""<html>
-  <body>
+        self.sidebar.load_html(f"""
     <style>
       body p, span {{ margin-top: 5px; margin-bottom: 5px; cursor: default; }}
       object {{ width: 100%; cursor: pointer; }}
@@ -331,8 +330,7 @@ class Page(ttk.Frame):
       <object allowscrolling data={html_button}></object>
       <object allowscrolling data={about_button}></object>
     </div>
-  </body>
-</html>""")
+    """)
         
         frame.config = self.html_config
 

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -1763,35 +1763,34 @@ class TkHtmlParsedURI:
         self.parsed = self.uri(uri)
 
     def __repr__(self):
-        return f"{self._html._w}::{self.__class__.__name__.lower()}"
+        return f"{self._html._w}::{self.__class__.__name__.lower()}{self.parsed}"
 
     def __str__(self):
-        return self.get(self.parsed)
+        return self.get
 
     def uri(self, uri):
         "Returns name of parsed uri to be used in methods below."
         return self._html.tk.call("::tkhtml::uri", uri)
 
-    def decode(self, uri, base64=False):
+    def decode(self, base64=False):
         "This command is designed to help scripts process data: URIs. It is completely separate from the html widget"
-        return self._html.decode_uri(uri, base64)
+        return self._html.decode_uri(self.get, base64)
 
-    def encode(self, uri):
+    def encode(self):
         "Encodes the uri."
-        return self._html.encode_uri(uri)
+        return self._html.encode_uri(self.get)
 
-    def escape(self, uri, query=False):
+    def escape(self, query=False):
         "Returns the decoded data."
-        return self._html.escape_uri(uri, query)
+        return self._html.escape_uri(self.get, query)
 
     def resolve(self, uri):
         "Resolve a uri."
         return self._html.tk.call(self.parsed, "resolve", uri)
 
-    @property
     def load(self, uri):
-        "Load a uri."
-        return self._html.tk.call(self.parsed, "load", uri)
+        "Load a URI, which overrides the previous URI string"
+        self._html.tk.call(self.parsed, "load", uri)
 
     @property
     def get(self):

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -297,7 +297,7 @@ If you benefited from using this package, please consider supporting its develop
         self.register_lazy_handler("node", "base", "node_manager")
         self.register_lazy_handler("attribute", "a", "node_manager")
 
-        if not self.using_tkhtml30:
+        if not self.using_tkhtml30 or self.experimental:
             #self.register_lazy_handler("node", "details", "node_manager")
             self.register_lazy_handler("node", "progress", "node_manager")
             self.register_lazy_handler("attribute", "progress", "node_manager")
@@ -676,7 +676,6 @@ It is likely that not all dependencies are installed. Make sure Cairo is install
         self.script_manager._submit_deferred_scripts()
         self.event_manager.send_onload()
 
-        #if self.using_tkhtml30: # Handle unsupported tags
         self.node_manager._handle_load_finish()
 
     def _handle_load_finish(self, post_event=True):

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -6,7 +6,7 @@ Copyright (c) 2021-2026 Andrew Clarke
 
 from re import IGNORECASE, split, sub
 
-from urllib.parse import urljoin
+from urllib.parse import urljoin, DefragResult
 
 from queue import Queue, Empty
 
@@ -1829,8 +1829,8 @@ class TkHtmlParsedURI:
 
     @property
     def splitfrag(self):
-        "Return namedtuple with uri and fragment"
-        return self.defrag, self.fragment
+        "Return DefragResult/namedtuple with uri and fragment"
+        return DefragResult(self.defrag, self.fragment)
 
     def destroy(self):
         "Destroy this uri and free Tcl resources."

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -1833,7 +1833,9 @@ class TkHtmlParsedURI:
         return self.defrag, self.fragment
 
     def destroy(self):
-        "Destroy this uri."
-        self._html.tk.call(self.parsed, "destroy")
+        "Destroy this uri and free Tcl resources."
+        if self.parsed:
+            self._html.tk.call(self.parsed, "destroy")
+            self.parsed = None
 
     __del__ = destroy

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -1768,24 +1768,21 @@ class TkHtmlParsedURI:
     def __str__(self):
         return self.get(self.parsed)
 
-    def __del__(self):
-        self.destroy(self.parsed)
-
     def uri(self, uri):
         "Returns name of parsed uri to be used in methods below."
         return self._html.tk.call("::tkhtml::uri", uri)
 
     def decode(self, uri, base64=False):
         "This command is designed to help scripts process data: URIs. It is completely separate from the html widget"
-        return self._html.tkhtml_uri_decode(uri, base64)
+        return self._html.decode_uri(uri, base64)
 
     def encode(self, uri):
         "Encodes the uri."
-        return self._html.tkhtml_uri_encode(uri)
+        return self._html.encode_uri(uri)
 
     def escape(self, uri, query=False):
         "Returns the decoded data."
-        return self._html.tkhtml_uri_escape(uri, query)
+        return self._html.escape_uri(uri, query)
 
     def resolve(self, uri):
         "Resolve a uri."
@@ -1839,3 +1836,5 @@ class TkHtmlParsedURI:
     def destroy(self):
         "Destroy this uri."
         self._html.tk.call(self.parsed, "destroy")
+
+    __del__ = destroy

--- a/tkinterweb/bindings.py
+++ b/tkinterweb/bindings.py
@@ -1750,8 +1750,7 @@ It is likely that not all dependencies are installed. Make sure Cairo is install
         """Returns the decoded data.
         
         New in version 4.19."""
-        a = "-query" if query else ""
-        return self.tk.call("::tkhtml::escape_uri", a, uri)
+        return self.tk.call("::tkhtml::escape_uri", "-query" if query else "", uri)
 
 class TkHtmlParsedURI:
     """Bindings for the Tkhtml URI parsing system. 
@@ -1777,19 +1776,19 @@ class TkHtmlParsedURI:
         "Returns name of parsed uri to be used in methods below."
         return self._html.tk.call("::tkhtml::uri", uri)
 
-    def tkhtml_uri_decode(self, uri, base64=False):
+    def decode(self, uri, base64=False):
         "This command is designed to help scripts process data: URIs. It is completely separate from the html widget"
         return self._html.tkhtml_uri_decode(uri, base64)
 
-    def tkhtml_uri_encode(self, uri):
+    def encode(self, uri):
         "Encodes the uri."
         return self._html.tkhtml_uri_encode(uri)
 
-    def tkhtml_uri_escape(self, uri, query=False):
+    def escape(self, uri, query=False):
         "Returns the decoded data."
         return self._html.tkhtml_uri_escape(uri, query)
 
-    def uri_resolve(self, uri):
+    def resolve(self, uri):
         "Resolve a uri."
         return self._html.tk.call(self.parsed, "resolve", uri)
 

--- a/tkinterweb/dom.py
+++ b/tkinterweb/dom.py
@@ -411,9 +411,9 @@ class HTMLElement:
                 self.html.widget_manager.set_node_widget(node, None)
 
             self.html.safe_tk_eval("""
-                set html %s
                 set node %s
                 set textnode %s
+                
                 if {$textnode eq ""} {error "$node is empty"}
                 if {[$node tag] eq "html"} {error "textContent cannot be set on <$tag> elements"}
                 $node remove [$node children]
@@ -422,8 +422,8 @@ class HTMLElement:
                 }
                 $node insert $textnode
                 
-                if {[winfo ismapped $html]} {update} ; # This must be done to see changes on-screen
-                """ % (self.html, extract_nested(self.node), self.document.createTextNode(contents).node)
+                if {[winfo ismapped .]} {update} ; # This must be done to see changes on-screen
+                """ % (extract_nested(self.node), self.document.createTextNode(contents).node)
             )
         else:
             self.html.set_node_text(self.node, contents)

--- a/tkinterweb/handlers.py
+++ b/tkinterweb/handlers.py
@@ -1,6 +1,24 @@
 """
 Node handlers and associated extensions to Tkhtml3
 
+This was created because TkinterWeb class was getting enormous and difficult to 
+maintain and debug. It was also full of old workarounds and meaningless code. 
+Generally, the Python philosophy is to have a self-explanatory, modular 
+codebase rather than one massive object that does a million things. It's been 
+on my bucket list for years to make the widget more modular, partly for this 
+reason. So, I split it into separate classes that each have a specific 
+function. This also simplified all the flags for extra features a lot: each 
+feature (i.e. images, CSS, etc.) is tied to a subclass that can be enabled or 
+disabled, saving me from having if/else statements everywhere checking if 
+actions are enabled. This also gave me the chance to add lazy loading into the 
+mix. Since less code has to be evaluated at startup, apps tend to start a bit 
+quicker (it's barely noticeable, but hey, I'll take it). Splitting off the node 
+handlers removes roughly 1000 lines from an object that as it is, is still 
+roughly at 1700 lines (which I personally think is still too much). Breaking 
+things into chunks just makes things simpler and easier to maintain. The 
+overhead in Python of creating another class is negligible, but the scalability 
+and ease of maintenance is much, much higher. That's my philosophy anyway!
+
 Copyright (c) 2021-2025 Andrew Clarke
 """
 

--- a/tkinterweb/handlers.py
+++ b/tkinterweb/handlers.py
@@ -297,20 +297,14 @@ class FormManager(utilities.BaseManager):
                     continue
                 elif nodetype == "file":
                     for value in nodevalue:
-                        data.append(
-                            (nodeattrname, value),
-                        )
+                        data.append((nodeattrname, value),)
                 else:
-                    data.append(
-                        (nodeattrname, nodevalue),
-                    )
+                    data.append((nodeattrname, nodevalue),)
         if not event:
             nodeattrname = self.html.get_node_attribute(node, "name")
             nodevalue = self.html.get_node_attribute(node, "value")
             if nodeattrname and nodevalue:
-                data.append(
-                    (nodeattrname, nodevalue),
-                )
+                data.append((nodeattrname, nodevalue),)
 
         data = urlencode(data)
 

--- a/tkinterweb/handlers.py
+++ b/tkinterweb/handlers.py
@@ -159,7 +159,7 @@ class NodeManager(utilities.BaseManager):
 
     def _set_open(self, node, display):
         self.html.set_node_attribute(node, "open", "" if display else "false")
-        if self.html.using_tkhtml30:
+        if self.html.using_tkhtml30 and not self.html.experimental:
             # In Tkhtml 3.1+ we add an attribute handler, which does this for us
             self._update_details(node, display)
 
@@ -204,7 +204,7 @@ class NodeManager(utilities.BaseManager):
         
         open = not self._is_open(details)
         self._set_open(details, open)
-        if open and self.html.using_tkhtml30:
+        if open and self.html.using_tkhtml30 or not self.html.experimental:
             self._close_other_details(details)
 
     def _on_progress(self, node):

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1576,10 +1576,9 @@ class HtmlLabel(HtmlFrame):
         self._style = Style()
 
         # Match the ttk theme
-        self._ttk_style_css(kwargs["style"])
+        self._ttk_style_css(kwargs)
 
         if text: self.load_html(text)
-        
         # I'd like to just make this an else statement to prevent the widget from being a massive white screen when text=""
         elif self.unshrink or (not self._html.using_tkhtml30 and not self._html.cget("textwrap")):
             # A fellow in issue 145 mentioned layout issues when this was used
@@ -1599,13 +1598,17 @@ class HtmlLabel(HtmlFrame):
             self.update_idletasks()
             self._html.relayout()
 
-    def _ttk_style_css(self, style_type):
+    def _ttk_style_css(self, kwargs):
+        style_type = kwargs["style"]
         bg = self._style.lookup(style_type, 'background')
         fg = self._style.lookup(style_type, 'foreground')
+        body_style = f"BODY {{ background-color: {bg}; color: {fg}; }}"
         style = self._html.default_style +\
             (self._html.dark_style if self._html.dark_theme_enabled else "") +\
-            f"BODY {{ background-color: {bg}; color: {fg}; }}"
+            body_style # This could it be done by appending `style`
+
         self._html.configure(defaultstyle=style)
+        self.add_css(body_style)
 
     def configure(self, **kwargs):
         "Sets the default value of the specified option(s) in Label/HTML."
@@ -1614,7 +1617,7 @@ class HtmlLabel(HtmlFrame):
             
         if "style" in kwargs:
             utilities.warn("Since version 4.14 the style keyword no longer sets the HtmlLabel's CSS code. Please use the add_css() method instead.")
-            self._ttk_style_css(kwargs["style"])
+            self._ttk_style_css(kwargs)
 
         if kwargs: super().configure(**kwargs)
 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -2191,15 +2191,24 @@ class HtmlParse(HtmlFrame):
         """HtmlParse needs its own method for loading documents so as not to use threading and load synchronously."""
         code = 404
         parsed = urlparse(url)
+
+        fragment = parsed.fragment
+
+        if fragment:
+            fragment = "".join(char for char in fragment if char.isalnum() or char in ("-", "_", ".")).replace(".", r"\.")
+
         try:
             newurl, data, filetype, code = self._html.download_url(url)
             self._html.post_message(f"Successfully connected to {newurl} {filetype}", True)
 
+            self._html.reset()
+            self._html.base_url = newurl
+            self._html.fragment = fragment
             self._html.parse(data)
 
         except Exception as error:
             self._html.post_message(f"ERROR: could not load {url}: {error}")
-            return error, code
+            return code, error
 
     # NOTE: could add shorthand methods for TkinderWeb handler commands, but may be excessive.
 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1543,11 +1543,10 @@ Otherwise, use 'HtmlFrame(master, insecure_https=True)' to ignore website certif
         else:
             self._html.unbind(sequence, *args, **kwargs)
     
-    def __getitem__(self, key):
-        return self.cget(key)
+    def __setitem__(self, k, v): self.configure({k: v})
 
-    def __setitem__(self, key, value):
-        self.configure(**{key: value})
+    __getitem__ = cget
+
 
 
 class HtmlLabel(HtmlFrame):

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -2187,6 +2187,22 @@ class HtmlParse(HtmlFrame):
     def __str__(self):
         return f"<html>{self.document.documentElement.innerHTML}</html>"
 
+    def webpage(self, url):
+        """HtmlParse needs its own method for loading documents so as not to use threading and load synchronously."""
+        code = 404
+        parsed = urlparse(url)
+        try:
+            newurl, data, filetype, code = self._html.download_url(url)
+            self._html.post_message(f"Successfully connected to {newurl} {filetype}", True)
+
+            self._html.parse(data)
+
+        except Exception as error:
+            self._html.post_message(f"ERROR: could not load {url}: {error}")
+            return error, code
+
+    # NOTE: could add shorthand methods for TkinderWeb handler commands, but may be excessive.
+
     def destroy(self):
         super().destroy()
         self.root.destroy()

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -524,6 +524,7 @@ class HtmlFrame(Frame):
         :type force: bool, optional"""
         ### TODO: Maybe consider merging load_url, load_file, and load_website into one
         ### One could use the checker from the sample web browser
+        if url.startswith("mailto") and not self._html.request_func: return  # Don't try to load emails!
         if not self._current_url == url:
             self._previous_url = self._current_url
         if url in utilities.BUILTIN_PAGES:

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1573,10 +1573,10 @@ class HtmlLabel(HtmlFrame):
         tags.remove("Html")
         self._html.bindtags(tags)
 
-        self._style = Style()
+        self._style = Style(self)
 
         # Match the ttk theme
-        self._ttk_style_css(kwargs)
+        self._ttk_style_css(kwargs, False)
 
         if text: self.load_html(text)
         # I'd like to just make this an else statement to prevent the widget from being a massive white screen when text=""
@@ -1598,7 +1598,7 @@ class HtmlLabel(HtmlFrame):
             self.update_idletasks()
             self._html.relayout()
 
-    def _ttk_style_css(self, kwargs):
+    def _ttk_style_css(self, kwargs, add_css):
         style_type = kwargs["style"]
         bg = self._style.lookup(style_type, 'background')
         fg = self._style.lookup(style_type, 'foreground')
@@ -1608,7 +1608,7 @@ class HtmlLabel(HtmlFrame):
             body_style # This could it be done by appending `style`
 
         self._html.configure(defaultstyle=style)
-        self.add_css(body_style)
+        if add_css: self.add_css(body_style, priority="agent")
 
     def configure(self, **kwargs):
         "Sets the default value of the specified option(s) in Label/HTML."
@@ -1617,7 +1617,7 @@ class HtmlLabel(HtmlFrame):
             
         if "style" in kwargs:
             utilities.warn("Since version 4.14 the style keyword no longer sets the HtmlLabel's CSS code. Please use the add_css() method instead.")
-            self._ttk_style_css(kwargs)
+            self._ttk_style_css(kwargs, True)
 
         if kwargs: super().configure(**kwargs)
 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1590,7 +1590,7 @@ class HtmlLabel(HtmlFrame):
         super().load_html(*args, **kwargs)
 
         # Match the ttk theme
-        self.add_css(utilities.ttk_style_css(self, self.cget("style")))
+        self.add_css(self._ttk_style_css(self.cget("style")))
 
         # This stops infinite flickering when tables are present
         # My computer was having this bug for a while but now I don't experience it
@@ -1600,6 +1600,15 @@ class HtmlLabel(HtmlFrame):
             self.update_idletasks()
             self._html.relayout()
 
+    @utilities.lru_cache()
+    def _ttk_style_css(self, style_type):
+        options = {
+            'background-color': 'background', 'color': 'foreground',
+        }
+        return "BODY {" + ";".join(
+             f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
+        ) + "}"
+
     def configure(self, **kwargs):
         ""
         if "text" in kwargs:
@@ -1607,7 +1616,7 @@ class HtmlLabel(HtmlFrame):
             
         if "style" in kwargs:
             utilities.warn("Since version 4.14 the style keyword no longer sets the HtmlLabel's CSS code. Please use the add_css() method instead.")
-            self.add_css(utilities.ttk_style_css(self, kwargs.pop("style")))
+            self.add_css(self._ttk_style_css(kwargs.pop("style")))
 
         if kwargs: super().configure(**kwargs)
 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -524,7 +524,7 @@ class HtmlFrame(Frame):
         :type force: bool, optional"""
         ### TODO: Maybe consider merging load_url, load_file, and load_website into one
         ### One could use the checker from the sample web browser
-        if url.startswith("mailto") and not self._html.request_func: return  # Don't try to load emails!
+        if url.startswith("mailto") and not self._html.request_func: return  # Don't try to load emails! this happend to me once!
         if not self._current_url == url:
             self._previous_url = self._current_url
         if url in utilities.BUILTIN_PAGES:
@@ -746,32 +746,31 @@ class HtmlFrame(Frame):
         :return: A string containing the PostScript code.
         :rtype: str
         :raise NotImplementedError: If experimental mode is not enabled."""
-        if self._html.experimental:
-            cnf |= kwargs
-            self._html.post_message(f"Printing {self._current_url}...")
-            if filename:
-                cnf["file"] = filename
-            if "pagesize" in cnf:
-                pagesizes = {
-                    "A3": "842x1191", "A4": "595x842", "A5": "420x595",
-                    "Legal": "612x792", "Letter": "612x1008"
-                }
-                try:
-                    cnf["pagesize"] = pagesizes[cnf["pagesize"].upper()]
-                    self._html.post_message(f"Setting printer page size to {cnf['pagesize']} PostScript points.")
-                except KeyError:
-                    raise KeyError("Parameter 'pagesize' must be A3, A4, A5, Legal, or Letter")
-
-            self._html.update() # Update the root window to ensure HTML is rendered
-            file = self._html.postscript(cnf)
-            
-            # No need to save - Tkhtml handles that for us
-            if filename:
-                self._html.post_message("Printed!")
-            if file: return file
-        else:
+        if not self._html.experimental:
             self._html.post_message("ERROR: The page could not be printed because print_page is an experimental feature")
             raise NotImplementedError("the page could not be printed because print_page is an experimental feature")
+
+        cnf |= kwargs
+        self._html.post_message(f"Printing {self._current_url}...")
+        if filename:
+            cnf["file"] = filename
+        if "pagesize" in cnf:
+            pagesizes = {
+                "A3": "842x1191", "A4": "595x842", "A5": "420x595",
+                "Legal": "612x792", "Letter": "612x1008"
+            }
+            try:
+                cnf["pagesize"] = pagesizes[cnf["pagesize"].upper()]
+                self._html.post_message(f"Setting printer page size to {cnf['pagesize']} PostScript points.")
+            except KeyError:
+                self._html.post_message(f"Setting printer page size to custom {cnf['pagesize']}.")
+
+        self._html.update() # Update the root window to ensure HTML is rendered
+        file = self._html.postscript(cnf)
+        
+        # No need to save - Tkhtml handles that for us
+        if filename: self._html.post_message("Printed!")
+        if file: return file
 
     def save_page(self, filename=None):
         """Return the page's HTML code or save the page as an HTML file.

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1586,17 +1586,19 @@ class HtmlLabel(HtmlFrame):
     
     def load_html(self, *args, _relayout=True, **kwargs):
         ""
-        # Match the ttk theme
-        style_type = self.cget("style")
-        bg = self._style.lookup(style_type, 'background')
-        fg = self._style.lookup(style_type, 'foreground')
-        style = self._html.default_style + \
-            (self._html.dark_style if self._html.dark_theme_enabled else "") +\
-            f"BODY {{ background-color: {bg}; color: {fg}; }}"
-        self._html.configure(defaultstyle=style)
-        
         # Load the HTML
         super().load_html(*args, **kwargs)
+
+        # Match the ttk theme
+        style_type = self.cget("style")
+        options = {
+            'background-color': 'background',
+            'color':            'foreground',
+        }
+        css = "BODY {" + ";".join(
+            f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
+        ) + "}"
+        self.add_css(css)
 
         # This stops infinite flickering when tables are present
         # My computer was having this bug for a while but now I don't experience it
@@ -1620,13 +1622,9 @@ class HtmlLabel(HtmlFrame):
         ""
         if "text" == key:
             return "".join(self._html.serialize_node(0).splitlines())
-        elif "style" == key:
-           return "".join(self._html.serialize_node_style(0).splitlines())
         return super().cget(key)
 
-    def config(self, **kwargs):
-        ""
-        self.configure(**kwargs)
+    config = configure
 
 class HtmlText(HtmlFrame):
     """The :class:`HtmlText` widget is a text-like HTML widget. It inherits from the :class:`HtmlFrame` class. 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1577,7 +1577,11 @@ class HtmlLabel(HtmlFrame):
 
         self._style = Style()
 
+        # Match the ttk theme
+        self._ttk_style_css(kwargs["style"])
+
         if text: self.load_html(text)
+        
         # I'd like to just make this an else statement to prevent the widget from being a massive white screen when text=""
         elif self.unshrink or (not self._html.using_tkhtml30 and not self._html.cget("textwrap")):
             # A fellow in issue 145 mentioned layout issues when this was used
@@ -1589,9 +1593,6 @@ class HtmlLabel(HtmlFrame):
         # Load the HTML
         super().load_html(*args, **kwargs)
 
-        # Match the ttk theme
-        self.add_css(self._ttk_style_css(self.cget("style")))
-
         # This stops infinite flickering when tables are present
         # My computer was having this bug for a while but now I don't experience it
         # But this doesn't seem to have any major side effects
@@ -1600,23 +1601,22 @@ class HtmlLabel(HtmlFrame):
             self.update_idletasks()
             self._html.relayout()
 
-    @utilities.lru_cache()
     def _ttk_style_css(self, style_type):
-        options = {
-            'background-color': 'background', 'color': 'foreground',
-        }
-        return "BODY {" + ";".join(
-             f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
-        ) + "}"
+        bg = self._style.lookup(style_type, 'background')
+        fg = self._style.lookup(style_type, 'foreground')
+        style = self._html.default_style +\
+            (self._html.dark_style if self._html.dark_theme_enabled else "") +\
+            f"BODY {{ background-color: {bg}; color: {fg}; }}"
+        self._html.configure(defaultstyle=style)
 
     def configure(self, **kwargs):
-        ""
+        "Sets the default value of the specified option(s) in Label/HTML."
         if "text" in kwargs:
             self.load_html(kwargs.pop("text"))
             
         if "style" in kwargs:
             utilities.warn("Since version 4.14 the style keyword no longer sets the HtmlLabel's CSS code. Please use the add_css() method instead.")
-            self.add_css(self._ttk_style_css(kwargs.pop("style")))
+            self._ttk_style_css(kwargs["style"])
 
         if kwargs: super().configure(**kwargs)
 

--- a/tkinterweb/htmlwidgets.py
+++ b/tkinterweb/htmlwidgets.py
@@ -1590,15 +1590,7 @@ class HtmlLabel(HtmlFrame):
         super().load_html(*args, **kwargs)
 
         # Match the ttk theme
-        style_type = self.cget("style")
-        options = {
-            'background-color': 'background',
-            'color':            'foreground',
-        }
-        css = "BODY {" + ";".join(
-            f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
-        ) + "}"
-        self.add_css(css)
+        self.add_css(utilities.ttk_style_css(self, self.cget("style")))
 
         # This stops infinite flickering when tables are present
         # My computer was having this bug for a while but now I don't experience it
@@ -1615,6 +1607,7 @@ class HtmlLabel(HtmlFrame):
             
         if "style" in kwargs:
             utilities.warn("Since version 4.14 the style keyword no longer sets the HtmlLabel's CSS code. Please use the add_css() method instead.")
+            self.add_css(utilities.ttk_style_css(self, kwargs.pop("style")))
 
         if kwargs: super().configure(**kwargs)
 

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -909,6 +909,17 @@ def check_download(url, data="", method="GET", decode=None, insecure=False, cafi
     return lru_cache.check(url, data, method, decode, insecure, cafile, headers, timeout)
 
 
+@lru_cache()
+def ttk_style_css(self, style_type):
+    options = {
+         'background-color': 'background',
+           'color':            'foreground',
+    }
+    return "BODY {" + ";".join(
+         f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
+    ) + "}"
+
+
 def shorten(string):
     "Shorten text to avoid overloading the terminal"
     if len(string) > 100:

--- a/tkinterweb/utilities.py
+++ b/tkinterweb/utilities.py
@@ -909,17 +909,6 @@ def check_download(url, data="", method="GET", decode=None, insecure=False, cafi
     return lru_cache.check(url, data, method, decode, insecure, cafile, headers, timeout)
 
 
-@lru_cache()
-def ttk_style_css(self, style_type):
-    options = {
-         'background-color': 'background',
-           'color':            'foreground',
-    }
-    return "BODY {" + ";".join(
-         f"{p}:{self._style.lookup(style_type, v)}" for p, v in options.items()
-    ) + "}"
-
-
 def shorten(string):
     "Shorten text to avoid overloading the terminal"
     if len(string) > 100:


### PR DESCRIPTION
Changes have been made chiefly to `TkHtmlParsedURI` and `HtmlLabel`. `.print_page` can now take custom page dimensions (TkHTML already handles this). 
`HtmlLabel` can now have its ttk Style replaced without reloading the document. However, I had to remove the `cget` `"style"` option, which doesn't seem to return anything anyway. I can add it back under a different name if required.

Please let me know if any adjustments are needed.